### PR TITLE
fix: correct data item generation loop to match number in log

### DIFF
--- a/lesson1/inter_less1_exer2_solution/src/main.c
+++ b/lesson1/inter_less1_exer2_solution/src/main.c
@@ -87,7 +87,7 @@ static void producer_func(void *unused1, void *unused2, void *unused3)
 		number of data items to send every time the producer thread is scheduled */
 		uint32_t data_number =
 			MIN_DATA_ITEMS + sys_rand32_get() % (MAX_DATA_ITEMS - MIN_DATA_ITEMS + 1);
-		for (int i = 0; i <= data_number; i++) {
+		for (int i = 0; i < data_number; i++) {
 			/* Create a data item to send */
 			struct data_item_t *buf = k_malloc(sizeof(struct data_item_t));
 			if (buf == NULL) {


### PR DESCRIPTION
Currently in function _producer_func()_ log prints message with Data Items Generated which is less by one compared to Data Items generated in _for()_ loop. This is because <= is used in loop condition instead of <.